### PR TITLE
Various GitHub Actions fixes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,4 @@
-name: mercapi CI
+name: Tests
 
 on:
   - push

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
         run: poetry install --only docs
 
       - name: Build docs
-        run: pdoc mercapi -o ./html
+        run: poetry run pdoc mercapi -o ./html
       
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,10 +1,8 @@
 name: Publish to TestPyPI
 
 on:
-  push:
-    branches:
-      - main
-      - 'release/**'
+  workflow_dispatch:
+    
 
 jobs:
   publish_test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,11 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types:
-      - 'released'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version
+        required: true
 
 jobs:
   publish_test:
@@ -21,3 +23,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Tag a commit
+        run: |
+          git tag ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# mercapi
+
+![PyPI](https://img.shields.io/pypi/v/mercapi)
+[![Tests](https://github.com/take-kun/mercapi/actions/workflows/check.yaml/badge.svg?branch=main)](https://github.com/take-kun/mercapi/actions/workflows/check.yaml)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mercapi)
+
+[API Documentation](https://take-kun.github.io/mercapi/)
+
 ## What is Mercapi?
 
 Mercapi is a Python wrapper for *mercari.jp* API.


### PR DESCRIPTION
- fix failing `Build and publish docs` workflow
- rename `Mercapi CI` to `Tests`
- add badges to README