### PR TITLE
feat: Add support for new Mercari API fields in items/get endpoint

### DIFF
--- a/mercapi/mapping/definitions.py
+++ b/mercapi/mapping/definitions.py
@@ -14,6 +14,18 @@ from mercapi.models.item.data import (
     ShippingDuration,
     ShippingClass,
     Comment,
+    Requester,
+    ItemSize,
+    ItemBrand,
+    ParentCategoryNtier,
+    ItemCategoryNtiers,
+    ItemAttribute,
+    ItemAttributeValue,
+    Defpay,
+    PromotionInstallment,
+    PricePromotionAreaDetails,
+    PromotionInfo,
+    EstimateInfo,
 )
 from mercapi.util.errors import ParseAPIResponseError
 from mercapi.models.base import ResponseModel
@@ -223,6 +235,75 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
             ResponseProperty(
                 "is_offerable_v2", "is_offerable_v2", Extractors.get("is_offerable_v2")
             ),
+            # New fields from updated API
+            ResponseProperty(
+                "requester", "requester", Extractors.get_as_model("requester", Requester)
+            ),
+            ResponseProperty(
+                "item_category_ntiers",
+                "item_category_ntiers",
+                Extractors.get_as_model("item_category_ntiers", ItemCategoryNtiers),
+            ),
+            ResponseProperty(
+                "parent_categories_ntiers",
+                "parent_categories_ntiers",
+                Extractors.get_list_of_model("parent_categories_ntiers", ParentCategoryNtier),
+            ),
+            ResponseProperty(
+                "item_size", "item_size", Extractors.get_as_model("item_size", ItemSize)
+            ),
+            ResponseProperty(
+                "item_brand", "item_brand", Extractors.get_as_model("item_brand", ItemBrand)
+            ),
+            ResponseProperty(
+                "registered_prices_count",
+                "registered_prices_count",
+                Extractors.get("registered_prices_count"),
+            ),
+            ResponseProperty(
+                "promotion_explanation_message",
+                "promotion_explanation_message",
+                Extractors.get("promotion_explanation_message"),
+            ),
+            ResponseProperty("hash_tags", "hash_tags", Extractors.get("hash_tags")),
+            ResponseProperty(
+                "additional_services",
+                "additional_services",
+                Extractors.get("additional_services"),
+            ),
+            ResponseProperty(
+                "item_attributes",
+                "item_attributes",
+                Extractors.get_list_of_model("item_attributes", ItemAttribute),
+            ),
+            ResponseProperty("is_dismissed", "is_dismissed", Extractors.get("is_dismissed")),
+            ResponseProperty(
+                "photo_descriptions",
+                "photo_descriptions",
+                Extractors.get("photo_descriptions"),
+            ),
+            ResponseProperty(
+                "has_active_mercard",
+                "has_active_mercard",
+                Extractors.get("has_active_mercard"),
+            ),
+            ResponseProperty(
+                "defpay", "defpay", Extractors.get_as_model("defpay", Defpay)
+            ),
+            ResponseProperty("meta_title", "meta_title", Extractors.get("meta_title")),
+            ResponseProperty(
+                "meta_subtitle", "meta_subtitle", Extractors.get("meta_subtitle")
+            ),
+            ResponseProperty(
+                "price_promotion_area_details",
+                "price_promotion_area_details",
+                Extractors.get_as_model("price_promotion_area_details", PricePromotionAreaDetails),
+            ),
+            ResponseProperty(
+                "estimate_info",
+                "estimate_info",
+                Extractors.get_as_model("estimate_info", EstimateInfo),
+            ),
         ],
     ),
     Seller: R(
@@ -274,6 +355,12 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
                 "star_rating_score",
                 Extractors.get("star_rating_score"),
             ),
+            ResponseProperty(
+                "is_followable", "is_followable", Extractors.get("is_followable")
+            ),
+            ResponseProperty(
+                "is_blocked", "is_blocked", Extractors.get("is_blocked")
+            ),
         ],
     ),
     Seller.Ratings: R(
@@ -289,7 +376,9 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
             ResponseProperty("id", "id_", Extractors.get("id")),
             ResponseProperty("name", "name", Extractors.get("name")),
         ],
-        optional_properties=[],
+        optional_properties=[
+            ResponseProperty("subname", "subname", Extractors.get("subname")),
+        ],
     ),
     Color: R(
         required_properties=[
@@ -579,6 +668,110 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
             ),
             ResponseProperty("isNoPrice", "is_no_price", Extractors.get("isNoPrice")),
         ],
+    ),
+    Requester: R(
+        required_properties=[
+            ResponseProperty("created", "created", Extractors.get_datetime("created")),
+        ],
+        optional_properties=[],
+    ),
+    ItemSize: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+        ],
+        optional_properties=[],
+    ),
+    ItemBrand: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+            ResponseProperty("sub_name", "sub_name", Extractors.get("sub_name")),
+        ],
+        optional_properties=[],
+    ),
+    ParentCategoryNtier: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+            ResponseProperty("display_order", "display_order", Extractors.get("display_order")),
+        ],
+        optional_properties=[],
+    ),
+    ItemCategoryNtiers: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+        ],
+        optional_properties=[
+            ResponseProperty("display_order", "display_order", Extractors.get("display_order")),
+            ResponseProperty("parent_category_id", "parent_category_id", Extractors.get("parent_category_id")),
+            ResponseProperty("parent_category_name", "parent_category_name", Extractors.get("parent_category_name")),
+            ResponseProperty("root_category_id", "root_category_id", Extractors.get("root_category_id")),
+            ResponseProperty("root_category_name", "root_category_name", Extractors.get("root_category_name")),
+            ResponseProperty("size_group_id", "size_group_id", Extractors.get("size_group_id")),
+            ResponseProperty("brand_group_id", "brand_group_id", Extractors.get("brand_group_id")),
+        ],
+    ),
+    ItemAttributeValue: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("text", "text", Extractors.get("text")),
+        ],
+        optional_properties=[],
+    ),
+    ItemAttribute: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("text", "text", Extractors.get("text")),
+            ResponseProperty("values", "values", Extractors.get_list_of_model("values", ItemAttributeValue)),
+            ResponseProperty("deep_facet_filterable", "deep_facet_filterable", Extractors.get("deep_facet_filterable")),
+            ResponseProperty("show_on_ui", "show_on_ui", Extractors.get("show_on_ui")),
+        ],
+        optional_properties=[],
+    ),
+    PromotionInstallment: R(
+        required_properties=[
+            ResponseProperty("message", "message", Extractors.get("message")),
+            ResponseProperty("campaign_message", "campaign_message", Extractors.get("campaign_message")),
+            ResponseProperty("campaign_url", "campaign_url", Extractors.get("campaign_url")),
+        ],
+        optional_properties=[],
+    ),
+    Defpay: R(
+        required_properties=[
+            ResponseProperty("calculated_price", "calculated_price", Extractors.get("calculated_price")),
+            ResponseProperty("is_easypay_heavy_user", "is_easypay_heavy_user", Extractors.get("is_easypay_heavy_user")),
+            ResponseProperty("has_ever_used_installment_payment", "has_ever_used_installment_payment", Extractors.get("has_ever_used_installment_payment")),
+            ResponseProperty("installment_monthly_amount", "installment_monthly_amount", Extractors.get("installment_monthly_amount")),
+            ResponseProperty("installment_times", "installment_times", Extractors.get("installment_times")),
+            ResponseProperty("promotion_installment", "promotion_installment", Extractors.get_as_model("promotion_installment", PromotionInstallment)),
+        ],
+        optional_properties=[],
+    ),
+    PromotionInfo: R(
+        required_properties=[
+            ResponseProperty("label_text", "label_text", Extractors.get("label_text")),
+            ResponseProperty("supplementary_text", "supplementary_text", Extractors.get("supplementary_text")),
+        ],
+        optional_properties=[],
+    ),
+    PricePromotionAreaDetails: R(
+        required_properties=[
+            ResponseProperty("promotion_type", "promotion_type", Extractors.get("promotion_type")),
+            ResponseProperty("promotion_info", "promotion_info", Extractors.get_list_of_model("promotion_info", PromotionInfo)),
+        ],
+        optional_properties=[],
+    ),
+    EstimateInfo: R(
+        required_properties=[
+            ResponseProperty("total_rate", "total_rate", Extractors.get("total_rate")),
+            ResponseProperty("mercard_estimate_reward", "mercard_estimate_reward", Extractors.get("mercard_estimate_reward")),
+            ResponseProperty("estimate_reward_text", "estimate_reward_text", Extractors.get("estimate_reward_text")),
+            ResponseProperty("disclaimer_text", "disclaimer_text", Extractors.get("disclaimer_text")),
+            ResponseProperty("lp_url", "lp_url", Extractors.get("lp_url")),
+        ],
+        optional_properties=[],
     ),
     ItemCategory: R(
         required_properties=[

--- a/mercapi/models/item/data.py
+++ b/mercapi/models/item/data.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from typing import List, Optional
 
 from mercapi.models.base import ResponseModel
 
@@ -26,12 +27,20 @@ class Seller(ResponseModel):
     is_official: bool
     quick_shipper: bool
     star_rating_score: int
+    is_followable: bool
+    is_blocked: bool
+
+
+@dataclass
+class Requester(ResponseModel):
+    created: datetime
 
 
 @dataclass
 class ItemCondition(ResponseModel):
     id_: int
     name: str
+    subname: Optional[str] = None
 
 
 @dataclass
@@ -97,3 +106,89 @@ class Comment(ResponseModel):
     message: str
     user: User
     created: datetime
+
+
+@dataclass
+class ItemSize(ResponseModel):
+    id_: int
+    name: str
+
+
+@dataclass
+class ItemBrand(ResponseModel):
+    id_: int
+    name: str
+    sub_name: str
+
+
+@dataclass
+class ParentCategoryNtier(ResponseModel):
+    id_: int
+    name: str
+    display_order: int
+
+
+@dataclass
+class ItemCategoryNtiers(ResponseModel):
+    id_: int
+    name: str
+    display_order: int
+    parent_category_id: int
+    parent_category_name: str
+    root_category_id: int
+    root_category_name: str
+    size_group_id: int
+    brand_group_id: int
+
+
+@dataclass
+class ItemAttributeValue(ResponseModel):
+    id_: str
+    text: str
+
+
+@dataclass
+class ItemAttribute(ResponseModel):
+    id_: str
+    text: str
+    values: List[ItemAttributeValue]
+    deep_facet_filterable: bool
+    show_on_ui: bool
+
+
+@dataclass
+class PromotionInstallment(ResponseModel):
+    message: str
+    campaign_message: str
+    campaign_url: str
+
+
+@dataclass
+class Defpay(ResponseModel):
+    calculated_price: int
+    is_easypay_heavy_user: bool
+    has_ever_used_installment_payment: bool
+    installment_monthly_amount: int
+    installment_times: int
+    promotion_installment: PromotionInstallment
+
+
+@dataclass
+class PromotionInfo(ResponseModel):
+    label_text: str
+    supplementary_text: str
+
+
+@dataclass
+class PricePromotionAreaDetails(ResponseModel):
+    promotion_type: str
+    promotion_info: List[PromotionInfo]
+
+
+@dataclass
+class EstimateInfo(ResponseModel):
+    total_rate: int
+    mercard_estimate_reward: int
+    estimate_reward_text: str
+    disclaimer_text: str
+    lp_url: str

--- a/mercapi/models/item/item.py
+++ b/mercapi/models/item/item.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from mercapi.models.base import ResponseModel
 from mercapi.models.common import ItemCategorySummary
@@ -14,6 +14,15 @@ from mercapi.models.item.data import (
     Color,
     Seller,
     Comment,
+    Requester,
+    ItemSize,
+    ItemBrand,
+    ParentCategoryNtier,
+    ItemCategoryNtiers,
+    ItemAttribute,
+    Defpay,
+    PricePromotionAreaDetails,
+    EstimateInfo,
 )
 
 
@@ -62,3 +71,22 @@ class Item(ResponseModel):
     has_additional_service: bool
     has_like_list: bool
     is_offerable_v2: bool
+    # New fields from updated API
+    requester: Optional[Requester] = None
+    item_category_ntiers: Optional[ItemCategoryNtiers] = None
+    parent_categories_ntiers: Optional[List[ParentCategoryNtier]] = None
+    item_size: Optional[ItemSize] = None
+    item_brand: Optional[ItemBrand] = None
+    registered_prices_count: Optional[int] = None
+    promotion_explanation_message: Optional[str] = None
+    hash_tags: Optional[List[str]] = None
+    additional_services: Optional[List[dict]] = None
+    item_attributes: Optional[List[ItemAttribute]] = None
+    is_dismissed: Optional[bool] = None
+    photo_descriptions: Optional[List[str]] = None
+    has_active_mercard: Optional[str] = None
+    defpay: Optional[Defpay] = None
+    meta_title: Optional[str] = None
+    meta_subtitle: Optional[str] = None
+    price_promotion_area_details: Optional[PricePromotionAreaDetails] = None
+    estimate_info: Optional[EstimateInfo] = None


### PR DESCRIPTION
This commit updates the Item model and related data structures to handle the new fields that have been added to the Mercari API JSON response from the "https://api.mercari.jp/items/get" endpoint.

New data models added:
- Requester: Contains requester creation timestamp
- ItemSize: Item size information (id, name)
- ItemBrand: Brand details (id, name, sub_name)
- ParentCategoryNtier: Category hierarchy information
- ItemCategoryNtiers: Extended category information with ntiers
- ItemAttribute & ItemAttributeValue: Item attributes and their values
- PromotionInstallment: Installment payment promotion details
- Defpay: Deferred payment information with installment details
- PromotionInfo: Promotion information details
- PricePromotionAreaDetails: Price promotion area details
- EstimateInfo: Estimate and reward information

Updated existing models:
- Seller: Added is_followable and is_blocked fields
- ItemCondition: Added optional subname field
- Item: Added 18 new optional fields to support the extended API response

New Item fields:
- requester, item_category_ntiers, parent_categories_ntiers
- item_size, item_brand, registered_prices_count
- promotion_explanation_message, hash_tags, additional_services
- item_attributes, is_dismissed, photo_descriptions
- has_active_mercard, defpay, meta_title, meta_subtitle
- price_promotion_area_details, estimate_info

All changes are backward compatible as new fields are optional.