### PR TITLE
Add support for new entities:search response fields

### DIFF
--- a/mercapi/mapping/definitions.py
+++ b/mercapi/mapping/definitions.py
@@ -4,6 +4,7 @@ from typing import NamedTuple, List, Dict, TypeVar, Type, Any, Optional, Callabl
 
 from mercapi.models import Item, Items, Profile, SearchResults, SearchResultItem
 from mercapi.models.common import ItemCategory, ItemCategorySummary
+from mercapi.models.search.search_result_item import ItemBrand, ItemSize, Photo, Auction, Shop
 from mercapi.models.item.data import (
     Seller,
     ItemCondition,
@@ -544,6 +545,42 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
         ],
         optional_properties=[],
     ),
+    ItemBrand: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+            ResponseProperty("subName", "sub_name", Extractors.get("subName")),
+        ],
+        optional_properties=[],
+    ),
+    ItemSize: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("name", "name", Extractors.get("name")),
+        ],
+        optional_properties=[],
+    ),
+    Photo: R(
+        required_properties=[
+            ResponseProperty("uri", "uri", Extractors.get("uri")),
+        ],
+        optional_properties=[],
+    ),
+    Auction: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+            ResponseProperty("bidDeadline", "bid_deadline", Extractors.get("bidDeadline")),
+            ResponseProperty("totalBid", "total_bid", Extractors.get("totalBid")),
+            ResponseProperty("highestBid", "highest_bid", Extractors.get("highestBid")),
+        ],
+        optional_properties=[],
+    ),
+    Shop: R(
+        required_properties=[
+            ResponseProperty("id", "id_", Extractors.get("id")),
+        ],
+        optional_properties=[],
+    ),
     SearchResultItem: R(
         required_properties=[
             ResponseProperty("id", "id_", Extractors.get("id")),
@@ -578,6 +615,41 @@ mapping_definitions: Dict[Type[ResponseModel], ResponseMappingDefinition] = {
                 Extractors.get_as("categoryId", int),
             ),
             ResponseProperty("isNoPrice", "is_no_price", Extractors.get("isNoPrice")),
+            ResponseProperty("buyerId", "buyer_id", Extractors.get("buyerId")),
+            ResponseProperty(
+                "itemSizes",
+                "item_sizes",
+                Extractors.get_list_of_model("itemSizes", ItemSize),
+            ),
+            ResponseProperty(
+                "itemBrand",
+                "item_brand",
+                Extractors.get_as_model("itemBrand", ItemBrand),
+            ),
+            ResponseProperty("itemPromotions", "item_promotions", Extractors.get("itemPromotions")),
+            ResponseProperty("shopName", "shop_name", Extractors.get("shopName")),
+            ResponseProperty(
+                "itemSize",
+                "item_size",
+                Extractors.get_as_model("itemSize", ItemSize),
+            ),
+            ResponseProperty("title", "title", Extractors.get("title")),
+            ResponseProperty("isLiked", "is_liked", Extractors.get("isLiked")),
+            ResponseProperty(
+                "photos",
+                "photos",
+                Extractors.get_list_of_model("photos", Photo),
+            ),
+            ResponseProperty(
+                "auction",
+                "auction",
+                Extractors.get_as_model("auction", Auction),
+            ),
+            ResponseProperty(
+                "shop",
+                "shop",
+                Extractors.get_as_model("shop", Shop),
+            ),
         ],
     ),
     ItemCategory: R(

--- a/mercapi/models/search/__init__.py
+++ b/mercapi/models/search/__init__.py
@@ -1,3 +1,10 @@
 from .meta import Meta
-from .search_result_item import SearchResultItem
+from .search_result_item import (
+    SearchResultItem,
+    ItemBrand,
+    ItemSize,
+    Photo,
+    Auction,
+    Shop,
+)
 from .search_results import SearchResults

--- a/mercapi/models/search/search_result_item.py
+++ b/mercapi/models/search/search_result_item.py
@@ -8,6 +8,42 @@ from mercapi.models.base import ResponseModel
 
 
 @dataclass
+class ItemBrand(ResponseModel):
+    """Brand information for an item"""
+    id_: str
+    name: str
+    sub_name: str
+
+
+@dataclass
+class ItemSize(ResponseModel):
+    """Size information for an item"""
+    id_: str
+    name: str
+
+
+@dataclass
+class Photo(ResponseModel):
+    """Photo information for an item"""
+    uri: str
+
+
+@dataclass
+class Auction(ResponseModel):
+    """Auction information for an item"""
+    id_: str
+    bid_deadline: str
+    total_bid: str
+    highest_bid: str
+
+
+@dataclass
+class Shop(ResponseModel):
+    """Shop information for an item"""
+    id_: str
+
+
+@dataclass
 class SearchResultItem(ResponseModel):
     id_: str
     name: str
@@ -23,6 +59,17 @@ class SearchResultItem(ResponseModel):
     shipping_method_id: int
     category_id: int
     is_no_price: bool  # price==9999999 if True
+    buyer_id: Optional[str] = None
+    item_sizes: Optional[List[ItemSize]] = None
+    item_brand: Optional[ItemBrand] = None
+    item_promotions: Optional[List] = None
+    shop_name: Optional[str] = None
+    item_size: Optional[ItemSize] = None
+    title: Optional[str] = None
+    is_liked: Optional[bool] = None
+    photos: Optional[List[Photo]] = None
+    auction: Optional[Auction] = None
+    shop: Optional[Shop] = None
 
     async def full_item(self) -> "Item":
         return await self._mercapi.item(self.id_)


### PR DESCRIPTION
- Add new model classes: ItemBrand, ItemSize, Photo, Auction, Shop
- Update SearchResultItem to include all new optional fields from API response
- Add mapping definitions for new nested objects
- Export new classes in search models __init__.py

New fields added to SearchResultItem:
- buyer_id: buyer identifier
- item_sizes: list of available sizes
- item_brand: brand information (id, name, sub_name)
- item_promotions: promotional information
- shop_name: name of shop
- item_size: selected item size
- title: item title
- is_liked: whether user has liked the item
- photos: list of photo objects with URIs
- auction: auction details (id, bid_deadline, total_bid, highest_bid)
- shop: shop details (id)

All existing tests pass successfully.